### PR TITLE
oralce cdc optimize and add source parallelism

### DIFF
--- a/src/main/java/org/example/streamers/OracleStreamer.java
+++ b/src/main/java/org/example/streamers/OracleStreamer.java
@@ -23,10 +23,7 @@ import org.example.utils.Thrower;
 import org.example.utils.Validator;
 
 import java.sql.*;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class OracleStreamer implements Streamer<String> {
@@ -54,7 +51,7 @@ public class OracleStreamer implements Streamer<String> {
     public OracleStreamer(JSONObject configJSON) {
         this.hostname = Validator.ensureNotEmpty("source.hostname", configJSON.getString("source.hostname"));
         this.port = Integer.parseInt(
-            Validator.ensureNotEmpty("source.port", configJSON.getString("source.port"))
+                Validator.ensureNotEmpty("source.port", configJSON.getString("source.port"))
         );
         this.databaseName = Validator.ensureNotEmpty("source.database.name", configJSON.getString("source.database.name"));
         this.schemaName = Validator.ensureNotEmpty("source.schema.name", configJSON.getString("source.schema.name"));
@@ -68,9 +65,9 @@ public class OracleStreamer implements Streamer<String> {
             this.tableArray = tableList.split(",");
 
             tableArray = Arrays.stream(tableArray)
-                .map(String::trim)
-                .map(tbl -> tbl.contains(".") ? tbl : schemaName + "." + tbl)
-                .toArray(String[]::new);
+                    .map(String::trim)
+                    .map(tbl -> tbl.contains(".") ? tbl : schemaName + "." + tbl)
+                    .toArray(String[]::new);
 
             tableList = String.join(",", tableArray);
         } else {
@@ -153,19 +150,19 @@ public class OracleStreamer implements Streamer<String> {
         //debeziumProperties.setProperty("database.pdb.name", pdbName);
 
         return OracleSourceBuilder.OracleIncrementalSource.<String>builder()
-            .hostname(hostname)
-            .port(port)
-            .username(username)
-            .password(password)
-            .databaseList(databaseName)
-            .schemaList(schemaName)
-            .tableList(tableList)
-            .deserializer(new OracleDebeziumToJSONDeserializer())
-            .debeziumProperties(debeziumProperties)
-            .startupOptions(startupOptions)
-            .fetchSize(fetchSize)
-            .splitSize(splitSize)
-            .build();
+                .hostname(hostname)
+                .port(port)
+                .username(username)
+                .password(password)
+                .databaseList(databaseName)
+                .schemaList(schemaName)
+                .tableList(tableList)
+                .deserializer(new OracleDebeziumToJSONDeserializer())
+                .debeziumProperties(debeziumProperties)
+                .startupOptions(startupOptions)
+                .fetchSize(fetchSize)
+                .splitSize(splitSize)
+                .build();
     }
 
     @Override
@@ -177,14 +174,18 @@ public class OracleStreamer implements Streamer<String> {
         LOG.info(String.format(">>> [ORACLE-STREAMER] CONNECTING TO: %s", connectionString));
 
         try (Connection connection = DriverManager.getConnection(
-            connectionString,
-            username,
-            password
+                connectionString,
+                username,
+                password
         )) {
             DatabaseMetaData metaData = connection.getMetaData();
             ResultSet tables = metaData.getTables(null, schemaName, "%", new String[]{"TABLE"});
+            List<String> actualTableNames = Arrays.stream(tableArray).map(t -> t.contains(".") ? t.substring(t.lastIndexOf('.') + 1) : t).collect(Collectors.toList());
             while (tables.next()) {
                 String tableName = tables.getString(3);
+                if (!actualTableNames.contains(tableName)) {
+                    continue;
+                }
                 String sanitizedTableName = Sanitizer.sanitize(tableName);
                 if (!tableName.equals(sanitizedTableName)) {
                     LOG.warn(">>> [ORACLE-STREAMER] TABLE NAME IS SANITIZED: {} -> {}", tableName, sanitizedTableName);
@@ -209,9 +210,9 @@ public class OracleStreamer implements Streamer<String> {
                 }
 
                 LOG.info(
-                    ">>> [MAIN] TAG-SCHEMA MAP FOR: {}{}", 
-                    String.format("%s.%s", sanitizedMappedDatabaseName, sanitizedTableName),
-                    (!sanitizedTableName.equals(sanitizedMappedTableName) ? ("(" + sanitizedMappedTableName + ")") : "")
+                        ">>> [MAIN] TAG-SCHEMA MAP FOR: {}{}",
+                        String.format("%s.%s", sanitizedMappedDatabaseName, sanitizedTableName),
+                        (!sanitizedTableName.equals(sanitizedMappedTableName) ? ("(" + sanitizedMappedTableName + ")") : "")
                 );
 
                 ResultSet columns = metaData.getColumns(databaseName, schemaName, tableName, "%");
@@ -223,10 +224,10 @@ public class OracleStreamer implements Streamer<String> {
 
                     if (!columnName.equals(sanitizedColumnName)) {
                         LOG.warn(
-                            ">>> [MAIN] COLUMN NAME SANITIZED: ({}) {} -> {}",
-                            sanitizedTableName,
-                            columnName,
-                            sanitizedColumnName
+                                ">>> [MAIN] COLUMN NAME SANITIZED: ({}) {} -> {}",
+                                sanitizedTableName,
+                                columnName,
+                                sanitizedColumnName
                         );
                     }
 
@@ -245,15 +246,16 @@ public class OracleStreamer implements Streamer<String> {
                 Schema avroSchema = fieldAssembler.endRecord();
 
                 final String outputTagID = String.format("%s__%s", sanitizedMappedDatabaseName, sanitizedMappedTableName);
-                final OutputTag<String> outputTag = new OutputTag<>(outputTagID) {};
+                final OutputTag<String> outputTag = new OutputTag<>(outputTagID) {
+                };
                 tagSchemaMap.put(sanitizedTableName, Tuple2.of(outputTag, avroSchema));
 
                 LOG.info(String.valueOf(avroSchema));
             }
         } catch (SQLException e) {
             Thrower.errAndThrow(
-                "ORACLE-STREAM",
-                String.format(">>> [MAIN] UNABLE TO CONNECT TO SOURCE, EXCEPTION: %s", e.getMessage())
+                    "ORACLE-STREAM",
+                    String.format(">>> [MAIN] UNABLE TO CONNECT TO SOURCE, EXCEPTION: %s", e.getMessage())
             );
         }
 
@@ -270,20 +272,21 @@ public class OracleStreamer implements Streamer<String> {
         Schema ddlAvroSchema = ddlFieldAssembler.endRecord();
 
         final String outputTagID = String.format("%s__%s", sanitizedDatabaseName, sanitizedDDLTableName);
-        final OutputTag<String> ddlOutputTag = new OutputTag<>(outputTagID) {};
+        final OutputTag<String> ddlOutputTag = new OutputTag<>(outputTagID) {
+        };
 
         tagSchemaMap.put(sanitizedDDLTableName, Tuple2.of(ddlOutputTag, ddlAvroSchema));
 
         LOG.info(
-            ">>> [MAIN] TAG-SCHEMA MAP FOR: {}", String.format("%s.%s", sanitizedDatabaseName, sanitizedDDLTableName)
+                ">>> [MAIN] TAG-SCHEMA MAP FOR: {}", String.format("%s.%s", sanitizedDatabaseName, sanitizedDDLTableName)
         );
         LOG.info(String.valueOf(ddlAvroSchema));
 
         this.tagSchemaStringMap = tagSchemaMap.entrySet().stream()
-            .collect(Collectors.toMap(
-                Map.Entry::getKey,
-                entry -> Tuple2.of(entry.getValue().f0, entry.getValue().f1.toString())
-            ));
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> Tuple2.of(entry.getValue().f0, entry.getValue().f1.toString())
+                ));
 
         return tagSchemaStringMap;
     }
@@ -295,11 +298,11 @@ public class OracleStreamer implements Streamer<String> {
         snapshotConfig.put("source.table.array", tableArray);
 
         return sourceStream
-            .keyBy(new NullByteKeySelector<>())
-            .process(new DelayedStopSignalProcessFunction(snapshotConfig))
-            .setParallelism(1)
-            .keyBy(new NullByteKeySelector<>())
-            .process(new SideInputProcessFunction(tagSchemaStringMap))
-            .setParallelism(1);
+                .keyBy(new NullByteKeySelector<>())
+                .process(new DelayedStopSignalProcessFunction(snapshotConfig))
+                .setParallelism(1)
+                .keyBy(new NullByteKeySelector<>())
+                .process(new SideInputProcessFunction(tagSchemaStringMap))
+                .setParallelism(1);
     }
 } 

--- a/src/main/resources/example-configs/mongodb-config.json
+++ b/src/main/resources/example-configs/mongodb-config.json
@@ -7,6 +7,7 @@
   "source.password": "",
   "source.database.name": "my-db",
   "source.collection.name": "my-db.my_coll",
+  "source.parallelism": 1,
   "mongodb.deserialization.mode": "top-level-string",
   "mongodb.connection.options": "authSource=admin&readPreference=secondaryPreferred",
   "snapshot.only": "false",

--- a/src/main/resources/example-configs/mysql-config.json
+++ b/src/main/resources/example-configs/mysql-config.json
@@ -8,6 +8,7 @@
   "source.password": "testtest",
   "source.timezone": "UTC",
   "source.database.name": "test",
+  "source.parallelism": 1,
   "snapshot.only": "false",
   "checkpoint.interval": 10,
   "checkpoint.storage": "filesystem",

--- a/src/main/resources/example-configs/oracle-config.json
+++ b/src/main/resources/example-configs/oracle-config.json
@@ -9,6 +9,7 @@
   "source.database.name": "xe",
   "source.schema.name": "HR",
   "source.table.list": "EMPLOYEES,DEPARTMENTS",
+  "source.parallelism": 1,
   "oracle.connection.options": "oracle.jdbc.fanEnabled=false",
   "snapshot.only": false,
   "checkpoint.interval": 10,


### PR DESCRIPTION
When retrieving table schemas from Oracle, only fetch the table structures for tables that exist in the configuration; Add source stream parallelism parameter, which defaults to 1 if not provided.